### PR TITLE
feat: releaser github action

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,109 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [linux, windows, macos]
+        include:
+          - name: linux
+            os: ubuntu-latest
+            artifact_name: target/release/cowin-notifier
+            asset_name: cowin-notifier-linux
+          - name: windows
+            os: windows-latest
+            artifact_name: target/release/cowin-notifier.exe
+            asset_name: cowin-notifier-windows
+          - name: macos
+            os: macos-latest
+            artifact_name: target/release/cowin-notifier
+            asset_name: cowin-notifier-macos
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Build
+        run: cargo build --release --locked
+
+      - name: Upload binaries to release
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.artifact_name }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: cowin-notifier-${{ github.ref }}
+          draft: false
+          prerelease: false
+  add:
+    name: Addding ${{ matrix.os }} build for release
+    runs-on: ubuntu-latest
+    needs: [build, release]
+    strategy:
+      matrix:
+        name: [linux, windows, macos]
+        include:
+          - name: linux
+            os: ubuntu-latest
+            download_name: cowin-notifier-linux
+            artifact_name: cowin-notifier-linux
+            asset_name: cowin-notifier
+          - name: windows
+            os: windows-latest
+            download_name: cowin-notifier-windows
+            artifact_name: cowin-notifier-windows.exe
+            asset_name: cowin-notifier.exe
+          - name: macos
+            os: macos-latest
+            download_name: cowin-notifier-macos
+            artifact_name: cowin-notifier-macos
+            asset_name: cowin-notifier
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.download_name }}
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Upload Artifact to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./${{ matrix.asset_name }}
+          asset_name: ${{ matrix.artifact_name }}
+          asset_content_type: application/zip


### PR DESCRIPTION
- Automate Releases

Steps to trigger a release: 

```bash
git tag vX.X
git push origin --tags
```

This will create a release named `cowin-notifier-vX.X` that will have windows, linux and mac binaries as straight downloadable and not zips!

Caution: Need to add a repo secret for github action to succeed.